### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing GitHub Skills activity that was announced by the principal.

## Changes
- Added "GitHub Skills" activity to the activities list in `app.py`
- Activity details:
  - Schedule: Mondays and Wednesdays, 3:30 PM - 5:00 PM
  - Max participants: 25
  - Description includes mention of GitHub Certifications program and college application benefits

## Fixes
Closes #6

## Context
This is time-sensitive as registrations close by the end of this week. The activity was already announced to students but was not available in the system for sign-ups.